### PR TITLE
Fix crash when using user-defined files without a debugger

### DIFF
--- a/AlotAddOnGUI/ui/ALOT_AddonUIMode_ThreadedTasks.cs
+++ b/AlotAddOnGUI/ui/ALOT_AddonUIMode_ThreadedTasks.cs
@@ -2041,7 +2041,7 @@ namespace AlotAddOnGUI
             AddonFile alotmainfile = AllAddonFiles.FirstOrDefault(x => x.ALOTVersion > 0 && ((x.Game_ME1 && game == 1) || (x.Game_ME2 && game == 2) || (x.Game_ME3 && game == 3)));
             foreach (AddonFile af in AllAddonFiles)
             {
-                if (af.UserFile) Debugger.Break();
+                if (af.UserFile && System.Diagnostics.Debugger.IsAttached) Debugger.Break();
                 //Check ALOT file is ready
                 if ((af.Game_ME1 && game == 1) || (af.Game_ME2 && game == 2) || (af.Game_ME3 && game == 3))
                 {
@@ -2103,7 +2103,7 @@ namespace AlotAddOnGUI
                     {
                         if (af.IsReady && af.GetFile() != null && File.Exists(af.GetFile()))
                         {
-                            if (af.GetFile() == null)
+                            if (af.GetFile() == null && System.Diagnostics.Debugger.IsAttached)
                             {
                                 Debugger.Break();
                             }


### PR DESCRIPTION
On some systems, when no debuggers are attached to the program, when
clicking on "Install for ME1" after supplying at least one
user-supplied file, a Windows crash dialog is shown. The dialog does not
close the program however.

This is due to calling Debugger.Break() even though no debuggers are
attached to the program, which shows a crash dialog on some systems.

This adds a check before using Debugger.Break() (in the two only
places where it is used) for whether a debugger is currently attached.
This both keeps the behaviour of interrupting if a debugger is attached,
and prevents showing a crash dialog if no debuggers are attached.

See: https://xamarin.github.io/bugzilla-archives/33/33952/bug.html